### PR TITLE
Cloud/offline UEMCP access: bootstrap, LFS scope presets, and auto-provisioning hook

### DIFF
--- a/.claude/UEMCP_CLOUD.md
+++ b/.claude/UEMCP_CLOUD.md
@@ -47,18 +47,52 @@ The offline tools parse **binary** `.uasset`/`.umap`. But cloud clones come down
 with LFS content as ~130-byte **pointer stubs** (git-lfs isn't smudged on clone),
 so without a pull the tools have nothing real to read — they'd only see stubs.
 
-The bootstrap installs `git-lfs` (via apt) and pulls just the project-authored
-content — `Content/ProjectFiles/**`, ~2.2 MB / 104 assets — deliberately skipping
-the ~4.3 GB of marketplace anim packs. Override with:
+The bootstrap installs `git-lfs` (via apt) and pulls a chosen **scope**,
+defaulting to just the project-authored content. Without this, the binary-decode
+tools (`read_asset_properties`, `query_asset_registry`, `inspect_blueprint`, the
+`bp_*` graph tools) are inert; with it they decode real serialized asset data —
+the same capability that produced
+[`docs/audits/AUDIT_UEMCP_OFFLINE_2026-05-29.md`](../docs/audits/AUDIT_UEMCP_OFFLINE_2026-05-29.md).
 
-- `UEMCP_LFS_INCLUDE` — space-separated include globs (default `Content/ProjectFiles/**`)
-- `UEMCP_SKIP_LFS=1` — skip the pull entirely (offline tools then see only
-  text-derived data: `project_info`, `get_build_config`, `list_config_values`)
+#### Scope presets
 
-Without this, the binary-decode tools (`read_asset_properties`,
-`query_asset_registry`, `inspect_blueprint`, the `bp_*` graph tools) are inert.
-With it, they decode real serialized asset data — the same capability that
-produced [`docs/audits/AUDIT_UEMCP_OFFLINE_2026-05-29.md`](../docs/audits/AUDIT_UEMCP_OFFLINE_2026-05-29.md).
+| Scope | Globs | Size | Use when |
+|-------|-------|------|----------|
+| `project` *(default)* | `Content/ProjectFiles/**` | ~2 MB / 105 | asset/config/blueprint integrity — the game's own data |
+| `anims` | + `Content/Assets/Animations/**` | ~2.85 GB | you need to introspect the marketplace anim packs |
+| `marketplace` | + `Content/Assets/**` | ~4.27 GB | all imported assets (anims, characters, VFX, SFX) |
+| `all` | everything LFS-tracked | ~4.28 GB | full parity with a local checkout |
+
+Set the **startup** scope by exporting one of these in the environment setup
+script *before* the bootstrap call:
+
+```bash
+export UEMCP_LFS_SCOPE=anims          # or: project | marketplace | all
+bash .claude/scripts/uemcp-cloud-bootstrap.sh
+```
+
+Other knobs:
+- `UEMCP_LFS_INCLUDE` — explicit space-separated globs (overrides the preset)
+- `UEMCP_SKIP_LFS=1` — skip the pull entirely
+
+#### Expanding scope on demand (mid-session)
+
+You don't have to decide up front. Start lean (`project`) and pull more whenever
+a task needs it — objects already cached are not re-downloaded:
+
+```bash
+# Check cost first (pulls nothing):
+bash .claude/scripts/uemcp-lfs-pull.sh anims --dry-run
+
+# Then pull a preset...
+bash .claude/scripts/uemcp-lfs-pull.sh anims
+
+# ...or just one pack by explicit glob:
+bash .claude/scripts/uemcp-lfs-pull.sh 'Content/Assets/Animations/ARPG_Samurai/**'
+```
+
+`uemcp-lfs-pull.sh` is the single source of truth for scope resolution, sizing,
+and pulling; the bootstrap delegates its step 4 to it.
 
 Once provisioned, the **`uemcp-offline`** server in [`.mcp.json`](../.mcp.json)
 loads native `mcp__uemcp-offline__*` tools automatically. It auto-attaches to this

--- a/.claude/UEMCP_CLOUD.md
+++ b/.claude/UEMCP_CLOUD.md
@@ -38,7 +38,27 @@ bash .claude/scripts/uemcp-cloud-bootstrap.sh
 That script (idempotent, safe to re-run):
 1. clones/updates the public `uemcp` repo into `$HOME/uemcp`,
 2. `npm install`s the server deps (skipped when the lockfile is unchanged),
-3. smoke-checks that the server boots headless.
+3. smoke-checks that the server boots headless,
+4. **materializes this project's binary assets from Git LFS** (see next section).
+
+### Why step 4 matters — LFS binaries
+
+The offline tools parse **binary** `.uasset`/`.umap`. But cloud clones come down
+with LFS content as ~130-byte **pointer stubs** (git-lfs isn't smudged on clone),
+so without a pull the tools have nothing real to read — they'd only see stubs.
+
+The bootstrap installs `git-lfs` (via apt) and pulls just the project-authored
+content — `Content/ProjectFiles/**`, ~2.2 MB / 104 assets — deliberately skipping
+the ~4.3 GB of marketplace anim packs. Override with:
+
+- `UEMCP_LFS_INCLUDE` — space-separated include globs (default `Content/ProjectFiles/**`)
+- `UEMCP_SKIP_LFS=1` — skip the pull entirely (offline tools then see only
+  text-derived data: `project_info`, `get_build_config`, `list_config_values`)
+
+Without this, the binary-decode tools (`read_asset_properties`,
+`query_asset_registry`, `inspect_blueprint`, the `bp_*` graph tools) are inert.
+With it, they decode real serialized asset data — the same capability that
+produced [`docs/audits/AUDIT_UEMCP_OFFLINE_2026-05-29.md`](../docs/audits/AUDIT_UEMCP_OFFLINE_2026-05-29.md).
 
 Once provisioned, the **`uemcp-offline`** server in [`.mcp.json`](../.mcp.json)
 loads native `mcp__uemcp-offline__*` tools automatically. It auto-attaches to this

--- a/.claude/UEMCP_CLOUD.md
+++ b/.claude/UEMCP_CLOUD.md
@@ -1,0 +1,91 @@
+# UEMCP in cloud (Claude Code on the web) sessions
+
+This project uses [UEMCP](https://github.com/noahbutcher97/uemcp) — Noah's Unreal
+Engine MCP bridge. UEMCP has **two layers**, and only one can run in a cloud
+session:
+
+| Layer | Transport | Needs a running editor? | Works in cloud? |
+|-------|-----------|-------------------------|-----------------|
+| **Offline** | reads `.uasset`/`.umap`/`.ini` + AssetRegistry from disk | No | ✅ **Yes** |
+| Live | TCP `55558` (C++ plugin), TCP `55557`, HTTP `30010` (Remote Control) | Yes | ❌ No editor in cloud |
+
+So in a web session you get the **offline toolset** (~18 read-only introspection
+tools: `project_info`, `query_asset_registry`, `read_asset_properties`,
+`inspect_blueprint`, `list_level_actors`, `list_gameplay_tags`, the `bp_*`
+graph-trace tools, etc.). Anything that mutates the editor or runs PIE requires
+your local machine.
+
+## Where the offline server lives
+
+**`$HOME/uemcp`** (i.e. `/home/user/uemcp` in a web container) — a sibling of the
+repo checkout, cloned fresh from the public repo each time the environment is
+provisioned. The consumed entrypoint is `$HOME/uemcp/server/server.mjs`.
+
+The container is ephemeral: the clone does **not** persist between sessions, which
+is why it is re-provisioned by a startup script rather than vendored into this
+repo.
+
+## How to make it import immediately (one-time setup)
+
+Add this line to your **environment setup script** (Claude Code on the web →
+environment settings → setup script). It runs when the container is provisioned,
+before any session starts, so the server file exists by the time MCP servers load:
+
+```bash
+bash .claude/scripts/uemcp-cloud-bootstrap.sh
+```
+
+That script (idempotent, safe to re-run):
+1. clones/updates the public `uemcp` repo into `$HOME/uemcp`,
+2. `npm install`s the server deps (skipped when the lockfile is unchanged),
+3. smoke-checks that the server boots headless.
+
+Once provisioned, the **`uemcp-offline`** server in [`.mcp.json`](../.mcp.json)
+loads native `mcp__uemcp-offline__*` tools automatically. It auto-attaches to this
+project via the workspace root the harness advertises — no manual `attach_project`
+needed. The offline toolset must be enabled once per session via the
+`enable_toolset` management tool (or `find_tools`), then its tools appear.
+
+### Overrides
+
+The bootstrap and wrapper honor:
+
+- `UEMCP_HOME` — install location (default `$HOME/uemcp`)
+- `UEMCP_REPO` — clone URL (default the public repo)
+- `UEMCP_REF`  — branch/tag/commit to check out (default: repo default branch)
+
+If you point `UEMCP_HOME` somewhere other than `$HOME/uemcp`, update the
+`uemcp-offline` `args` path in `.mcp.json` to match.
+
+## Guaranteed CLI path (no MCP handshake)
+
+For scripts, CI, or when you just want raw output, drive the offline tools
+directly — this bypasses MCP entirely and is the most reliable path:
+
+```bash
+node .claude/scripts/uemcp-offline.mjs                 # list offline tools
+node .claude/scripts/uemcp-offline.mjs project_info
+node .claude/scripts/uemcp-offline.mjs query_asset_registry \
+  '{"path_prefix":"/Game/ProjectFiles/Data/PDA/Attack","limit":200}'
+node .claude/scripts/uemcp-offline.mjs read_asset_properties \
+  '{"asset_path":"Content/ProjectFiles/Data/PDA/Attack/AttackConfigurations/DA_Config_Katana.uasset"}'
+```
+
+Defaults `UNREAL_PROJECT_ROOT` to this repo's root. This is the same tooling that
+produced [`docs/audits/AUDIT_UEMCP_OFFLINE_2026-05-29.md`](../docs/audits/AUDIT_UEMCP_OFFLINE_2026-05-29.md).
+
+## Windows / local machines
+
+Untouched. The native `uemcp` entry in `.mcp.json` (pointing at
+`D:/DevTools/UEMCP`) still drives the full live + offline surface locally. The
+`uemcp-offline` entry resolves to a `${HOME}/uemcp` path that doesn't exist on
+Windows, so it stays inert there.
+
+## Known limitation (cloud native-MCP attach)
+
+Native-MCP offline attach relies on the client advertising a workspace root that
+contains the `.uproject` — which the Claude Code harness does. Launching the
+server over a raw stdio pipe with **no** roots advertised (and no
+`UEMCP_PROJECT_ATTACH_MODE=env`) leaves the offline layer reporting
+`PROJECT_NOT_ATTACHED`. If native tools ever show unavailable, fall back to the
+CLI wrapper above, which does not depend on attach state.

--- a/.claude/UEMCP_CLOUD.md
+++ b/.claude/UEMCP_CLOUD.md
@@ -75,6 +75,16 @@ Other knobs:
 - `UEMCP_LFS_INCLUDE` — explicit space-separated globs (overrides the preset)
 - `UEMCP_SKIP_LFS=1` — skip the pull entirely
 
+#### Automatic per-session provisioning (SessionStart hook)
+
+`.claude/settings.json` wires a `SessionStart` hook to
+`uemcp-session-start.sh`, so **cloud sessions self-provision the `project`
+scope with zero manual steps** — including phone-initiated sessions. The hook
+is cloud-only by three layered guards: it exits immediately on non-Linux, on
+machines without the Claude cloud container env markers
+(`CLAUDE_CODE_CONTAINER_ID` / `CCR_AGENT_PROXY_ENABLED`), and when binaries are
+already materialized. Local Windows/Linux checkouts are never touched.
+
 #### Expanding scope on demand (mid-session)
 
 You don't have to decide up front. Start lean (`project`) and pull more whenever

--- a/.claude/scripts/uemcp-cloud-bootstrap.sh
+++ b/.claude/scripts/uemcp-cloud-bootstrap.sh
@@ -20,12 +20,20 @@
 #   UEMCP_HOME   install location            (default: $HOME/uemcp)
 #   UEMCP_REPO   clone URL (public repo)     (default: https://github.com/noahbutcher97/uemcp)
 #   UEMCP_REF    branch/tag/commit to check  (default: repo default branch)
-set -eu
+set -euf   # -f (noglob): keep $UEMCP_LFS_INCLUDE patterns literal for git-lfs;
+           # the script never relies on shell filename expansion (uses find).
 
 UEMCP_HOME="${UEMCP_HOME:-$HOME/uemcp}"
 UEMCP_REPO="${UEMCP_REPO:-https://github.com/noahbutcher97/uemcp}"
 UEMCP_REF="${UEMCP_REF:-}"
 SERVER_DIR="$UEMCP_HOME/server"
+
+# Which of THIS project's LFS binaries to fetch so the offline tools have real
+# assets to read. Default: project-authored content only (~2 MB), skipping the
+# multi-GB marketplace anim packs. Set UEMCP_SKIP_LFS=1 to skip entirely, or
+# override the include globs (space-separated).
+UEMCP_LFS_INCLUDE="${UEMCP_LFS_INCLUDE:-Content/ProjectFiles/**}"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
 log() { printf '[uemcp-bootstrap] %s\n' "$*" >&2; }
 
@@ -94,6 +102,55 @@ if ( cd "$SERVER_DIR" && printf '%s\n' \
 else
   # A non-zero exit here is expected (server waits on stdin); treat as best-effort.
   log "OK — UEMCP provisioned at $SERVER_DIR (headless smoke inconclusive; this is normal)"
+fi
+
+# 4. Provision this project's LFS binaries -------------------------------
+# Cloud clones come down with LFS content as pointer stubs (git-lfs not smudged
+# on clone). uemcp offline tools parse binary .uasset/.umap, so without real
+# bytes they have nothing to read. Fetch just the project-authored content.
+if [ "${UEMCP_SKIP_LFS:-0}" = "1" ]; then
+  log "UEMCP_SKIP_LFS=1 — skipping project LFS provisioning"
+else
+  PROJECT_REPO="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo '')"
+  if [ -z "$PROJECT_REPO" ]; then
+    log "not inside a git repo; skipping LFS pull"
+  elif ! grep -q 'filter=lfs' "$PROJECT_REPO/.gitattributes" 2>/dev/null; then
+    log "project has no LFS-tracked files; skipping LFS pull"
+  else
+    if ! command -v git-lfs >/dev/null 2>&1; then
+      log "installing git-lfs"
+      ( apt-get install -y git-lfs >/dev/null 2>&1 || sudo apt-get install -y git-lfs >/dev/null 2>&1 ) \
+        || log "could not install git-lfs; offline tools will see pointer stubs, not binaries"
+    fi
+    if command -v git-lfs >/dev/null 2>&1; then
+      git -C "$PROJECT_REPO" lfs install --skip-smudge >/dev/null 2>&1 || true
+      inc_args=""
+      for glob in $UEMCP_LFS_INCLUDE; do inc_args="$inc_args --include=$glob"; done
+      log "pulling project LFS binaries ($UEMCP_LFS_INCLUDE)"
+      # shellcheck disable=SC2086
+      git -C "$PROJECT_REPO" lfs pull $inc_args >/dev/null 2>&1 || \
+        log "lfs pull reported an error (network policy?); attempting checkout from cache"
+      # `git lfs pull` skips the working-tree rewrite when smudge is disabled;
+      # force-materialize the pointers we just fetched.
+      for glob in $UEMCP_LFS_INCLUDE; do
+        git -C "$PROJECT_REPO" lfs checkout "${glob%/**}" >/dev/null 2>&1 || true
+      done
+      # Verify by size: a materialized .uasset is >1 KB; a pointer stub is ~130 B.
+      # Count real files across the pulled roots rather than sampling one.
+      real_ct=0
+      for glob in $UEMCP_LFS_INCLUDE; do
+        root="$PROJECT_REPO/${glob%%/**}"
+        [ -d "$root" ] || continue
+        n=$(find "$root" -name '*.uasset' -size +1k 2>/dev/null | wc -l)
+        real_ct=$((real_ct + n))
+      done
+      if [ "$real_ct" -gt 0 ]; then
+        log "OK — $real_ct project binaries materialized for offline introspection"
+      else
+        log "WARN — binaries still look like LFS pointers; offline tools limited to text-derived data"
+      fi
+    fi
+  fi
 fi
 
 log "done. Native offline tools load via the 'uemcp-offline' server in .mcp.json."

--- a/.claude/scripts/uemcp-cloud-bootstrap.sh
+++ b/.claude/scripts/uemcp-cloud-bootstrap.sh
@@ -29,10 +29,12 @@ UEMCP_REF="${UEMCP_REF:-}"
 SERVER_DIR="$UEMCP_HOME/server"
 
 # Which of THIS project's LFS binaries to fetch so the offline tools have real
-# assets to read. Default: project-authored content only (~2 MB), skipping the
-# multi-GB marketplace anim packs. Set UEMCP_SKIP_LFS=1 to skip entirely, or
-# override the include globs (space-separated).
-UEMCP_LFS_INCLUDE="${UEMCP_LFS_INCLUDE:-Content/ProjectFiles/**}"
+# assets to read. Controlled by (in priority order):
+#   UEMCP_LFS_INCLUDE  explicit space-separated globs (power users)
+#   UEMCP_LFS_SCOPE    preset keyword: project (default) | anims | marketplace | all
+#   UEMCP_SKIP_LFS=1   skip LFS entirely
+# Scope resolution + sizing + pulling live in uemcp-lfs-pull.sh (also runnable
+# standalone mid-session to expand scope). Default is project-only (~2 MB).
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 
 log() { printf '[uemcp-bootstrap] %s\n' "$*" >&2; }
@@ -107,7 +109,8 @@ fi
 # 4. Provision this project's LFS binaries -------------------------------
 # Cloud clones come down with LFS content as pointer stubs (git-lfs not smudged
 # on clone). uemcp offline tools parse binary .uasset/.umap, so without real
-# bytes they have nothing to read. Fetch just the project-authored content.
+# bytes they have nothing to read. Delegate to the shared pull script, which
+# also powers on-demand scope expansion (project | anims | marketplace | all).
 if [ "${UEMCP_SKIP_LFS:-0}" = "1" ]; then
   log "UEMCP_SKIP_LFS=1 — skipping project LFS provisioning"
 else
@@ -117,39 +120,11 @@ else
   elif ! grep -q 'filter=lfs' "$PROJECT_REPO/.gitattributes" 2>/dev/null; then
     log "project has no LFS-tracked files; skipping LFS pull"
   else
-    if ! command -v git-lfs >/dev/null 2>&1; then
-      log "installing git-lfs"
-      ( apt-get install -y git-lfs >/dev/null 2>&1 || sudo apt-get install -y git-lfs >/dev/null 2>&1 ) \
-        || log "could not install git-lfs; offline tools will see pointer stubs, not binaries"
-    fi
-    if command -v git-lfs >/dev/null 2>&1; then
-      git -C "$PROJECT_REPO" lfs install --skip-smudge >/dev/null 2>&1 || true
-      inc_args=""
-      for glob in $UEMCP_LFS_INCLUDE; do inc_args="$inc_args --include=$glob"; done
-      log "pulling project LFS binaries ($UEMCP_LFS_INCLUDE)"
-      # shellcheck disable=SC2086
-      git -C "$PROJECT_REPO" lfs pull $inc_args >/dev/null 2>&1 || \
-        log "lfs pull reported an error (network policy?); attempting checkout from cache"
-      # `git lfs pull` skips the working-tree rewrite when smudge is disabled;
-      # force-materialize the pointers we just fetched.
-      for glob in $UEMCP_LFS_INCLUDE; do
-        git -C "$PROJECT_REPO" lfs checkout "${glob%/**}" >/dev/null 2>&1 || true
-      done
-      # Verify by size: a materialized .uasset is >1 KB; a pointer stub is ~130 B.
-      # Count real files across the pulled roots rather than sampling one.
-      real_ct=0
-      for glob in $UEMCP_LFS_INCLUDE; do
-        root="$PROJECT_REPO/${glob%%/**}"
-        [ -d "$root" ] || continue
-        n=$(find "$root" -name '*.uasset' -size +1k 2>/dev/null | wc -l)
-        real_ct=$((real_ct + n))
-      done
-      if [ "$real_ct" -gt 0 ]; then
-        log "OK — $real_ct project binaries materialized for offline introspection"
-      else
-        log "WARN — binaries still look like LFS pointers; offline tools limited to text-derived data"
-      fi
-    fi
+    # UEMCP_LFS_INCLUDE (explicit globs) overrides UEMCP_LFS_SCOPE (keyword).
+    LFS_ARG="${UEMCP_LFS_INCLUDE:-${UEMCP_LFS_SCOPE:-project}}"
+    # shellcheck disable=SC2086
+    bash "$SCRIPT_DIR/uemcp-lfs-pull.sh" $LFS_ARG || \
+      log "LFS provisioning had issues; offline tools may be limited to text-derived data"
   fi
 fi
 

--- a/.claude/scripts/uemcp-cloud-bootstrap.sh
+++ b/.claude/scripts/uemcp-cloud-bootstrap.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# uemcp-cloud-bootstrap.sh
+#
+# Provision Noah's UEMCP server into a cloud/Linux Claude Code session so its
+# OFFLINE toolset (disk-only .uasset/.umap/.ini/AssetRegistry parsing) is
+# available with no running Unreal Editor.
+#
+# The LIVE layers (TCP:55558 C++ plugin, HTTP:30010 Remote Control) cannot work
+# in the cloud — there is no editor — so only the offline toolset is provisioned.
+#
+# This script is IDEMPOTENT and safe to run on every session start. Intended to
+# be invoked from the environment's setup script (Claude Code on the web):
+#
+#     bash .claude/scripts/uemcp-cloud-bootstrap.sh
+#
+# Result: the server lives at $UEMCP_HOME/server (default: $HOME/uemcp/server),
+# consumed by the "uemcp-offline" entry in .mcp.json and by uemcp-offline.mjs.
+#
+# Overridable env:
+#   UEMCP_HOME   install location            (default: $HOME/uemcp)
+#   UEMCP_REPO   clone URL (public repo)     (default: https://github.com/noahbutcher97/uemcp)
+#   UEMCP_REF    branch/tag/commit to check  (default: repo default branch)
+set -eu
+
+UEMCP_HOME="${UEMCP_HOME:-$HOME/uemcp}"
+UEMCP_REPO="${UEMCP_REPO:-https://github.com/noahbutcher97/uemcp}"
+UEMCP_REF="${UEMCP_REF:-}"
+SERVER_DIR="$UEMCP_HOME/server"
+
+log() { printf '[uemcp-bootstrap] %s\n' "$*" >&2; }
+
+# Windows/local machines already have the real server (D:/DevTools/UEMCP) and the
+# native "uemcp" .mcp.json entry — do not interfere there.
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  Linux|Darwin) : ;;
+  *) log "non-POSIX host detected; skipping cloud bootstrap (local setup owns UEMCP)"; exit 0 ;;
+esac
+
+command -v git  >/dev/null 2>&1 || { log "git not found; cannot provision UEMCP"; exit 0; }
+command -v node >/dev/null 2>&1 || { log "node not found; cannot provision UEMCP"; exit 0; }
+
+clone_fresh() {
+  rm -rf "$UEMCP_HOME"
+  n=0
+  until [ "$n" -ge 4 ]; do
+    if git clone --depth 1 "$UEMCP_REPO" "$UEMCP_HOME"; then return 0; fi
+    n=$((n + 1)); wait=$((2 ** n))
+    log "clone failed (attempt $n); retrying in ${wait}s"
+    sleep "$wait"
+  done
+  log "clone failed after retries"; return 1
+}
+
+# 1. Clone or update -------------------------------------------------------
+if git -C "$UEMCP_HOME" rev-parse HEAD >/dev/null 2>&1; then
+  log "existing checkout at $UEMCP_HOME; fetching latest"
+  git -C "$UEMCP_HOME" fetch --depth 1 origin >/dev/null 2>&1 || log "fetch failed; using cached checkout"
+  git -C "$UEMCP_HOME" reset --hard "origin/$(git -C "$UEMCP_HOME" rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's#^origin/##' || echo HEAD)" >/dev/null 2>&1 || true
+else
+  log "cloning $UEMCP_REPO -> $UEMCP_HOME"
+  clone_fresh || exit 1
+fi
+
+if [ -n "$UEMCP_REF" ]; then
+  log "checking out ref: $UEMCP_REF"
+  git -C "$UEMCP_HOME" fetch --depth 1 origin "$UEMCP_REF" >/dev/null 2>&1 || true
+  git -C "$UEMCP_HOME" checkout -q "$UEMCP_REF" 2>/dev/null || log "ref $UEMCP_REF not found; staying on default branch"
+fi
+
+[ -f "$SERVER_DIR/server.mjs" ] || { log "server.mjs missing after checkout — unexpected repo layout"; exit 1; }
+
+# 2. Install server deps (skip if lockfile unchanged since last install) ----
+STAMP="$SERVER_DIR/node_modules/.uemcp-bootstrap-stamp"
+LOCK="$SERVER_DIR/package-lock.json"
+LOCK_HASH="$( ( [ -f "$LOCK" ] && sha1sum "$LOCK" || echo none ) | awk '{print $1}')"
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP" 2>/dev/null)" = "$LOCK_HASH" ]; then
+  log "deps already installed (lockfile unchanged); skipping npm install"
+else
+  log "installing server deps"
+  if [ -f "$LOCK" ]; then
+    ( cd "$SERVER_DIR" && npm ci --no-audit --no-fund ) || \
+    ( cd "$SERVER_DIR" && npm install --no-audit --no-fund )
+  else
+    ( cd "$SERVER_DIR" && npm install --no-audit --no-fund )
+  fi
+  printf '%s' "$LOCK_HASH" > "$STAMP"
+fi
+
+# 3. Smoke check: server boots headless and indexes tools ------------------
+if ( cd "$SERVER_DIR" && printf '%s\n' \
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"bootstrap","version":"0"}}}' \
+    | timeout 20 node server.mjs >/dev/null 2>&1 ); then
+  log "OK — UEMCP offline server ready at $SERVER_DIR"
+else
+  # A non-zero exit here is expected (server waits on stdin); treat as best-effort.
+  log "OK — UEMCP provisioned at $SERVER_DIR (headless smoke inconclusive; this is normal)"
+fi
+
+log "done. Native offline tools load via the 'uemcp-offline' server in .mcp.json."
+log "Direct CLI: node .claude/scripts/uemcp-offline.mjs project_info"

--- a/.claude/scripts/uemcp-lfs-pull.sh
+++ b/.claude/scripts/uemcp-lfs-pull.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# uemcp-lfs-pull.sh — materialize this project's Git LFS binaries so the UEMCP
+# offline tools have real .uasset/.umap bytes to parse.
+#
+# Cloud clones bring LFS content down as ~130 B pointer stubs. This pulls the
+# real objects for a chosen SCOPE. Safe to run standalone at any time to EXPAND
+# what's materialized in a running session — LFS objects already cached are not
+# re-downloaded.
+#
+# Usage:
+#   bash .claude/scripts/uemcp-lfs-pull.sh [scope|glob ...] [--dry-run]
+#
+#   scope keyword (default: project):
+#     project       Content/ProjectFiles/**                     (~2 MB)   the game's own content
+#     anims         + Content/Assets/Animations/**              (~2.9 GB) project + marketplace anim packs
+#     marketplace   + Content/Assets/**                         (~4.3 GB) project + all imported assets
+#     all           everything LFS-tracked                      (~4.3 GB)
+#
+#   explicit globs (contain a "/"): pulled verbatim, e.g.
+#     bash .claude/scripts/uemcp-lfs-pull.sh 'Content/Assets/Animations/ARPG_Samurai/**'
+#
+#   --dry-run   resolve the scope and print the on-disk size, pull nothing.
+#
+# Env: UEMCP_LFS_SCOPE / UEMCP_LFS_INCLUDE mirror the positional args (args win).
+set -euf
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+PROJECT_REPO="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || echo '')"
+
+log() { printf '[uemcp-lfs] %s\n' "$*" >&2; }
+
+[ -n "$PROJECT_REPO" ] || { log "not inside a git repo"; exit 1; }
+
+# ── Parse args ────────────────────────────────────────────────────────────
+DRYRUN=0
+POS=""
+for a in "$@"; do
+  case "$a" in
+    --dry-run|-n) DRYRUN=1 ;;
+    *) POS="$POS $a" ;;
+  esac
+done
+POS="${POS# }"
+[ -n "$POS" ] || POS="${UEMCP_LFS_INCLUDE:-${UEMCP_LFS_SCOPE:-project}}"
+
+# ── Resolve scope keyword -> include globs (empty INCLUDE => everything) ────
+# First token decides: a known keyword expands to a preset; anything with "/"
+# means the caller passed explicit globs (use POS verbatim).
+first="${POS%% *}"
+case "$first" in
+  project)     INCLUDE="Content/ProjectFiles/**" ;;
+  anims)       INCLUDE="Content/ProjectFiles/** Content/Assets/Animations/**" ;;
+  marketplace) INCLUDE="Content/ProjectFiles/** Content/Assets/**" ;;
+  all)         INCLUDE="" ;;
+  *)           case "$first" in */*) INCLUDE="$POS" ;; *)
+                 log "unknown scope '$first' (use: project | anims | marketplace | all | <glob>)"; exit 2 ;;
+               esac ;;
+esac
+
+# ── Size estimate for the resolved scope ──────────────────────────────────
+size_of() {  # args: include globs (none => all)
+  if [ "$#" -eq 0 ]; then
+    git -C "$PROJECT_REPO" lfs ls-files -s 2>/dev/null
+  else
+    inc=""; for g in "$@"; do inc="$inc -I $g"; done
+    # shellcheck disable=SC2086
+    git -C "$PROJECT_REPO" lfs ls-files -s $inc 2>/dev/null
+  fi | awk '
+    { i=match($0,/\([0-9.]+ [KMG]B\)$/); if(!i)next; s=substr($0,i+1); gsub(/[()]/,"",s);
+      split(s,su," "); v=su[1]; u=su[2];
+      if(u=="KB")v*=1024; else if(u=="MB")v*=1048576; else if(u=="GB")v*=1073741824; t+=v; c++ }
+    END{ printf "%.1f MB across %d files", t/1048576, c }'
+}
+
+# shellcheck disable=SC2086
+if [ -z "$INCLUDE" ]; then EST="$(size_of)"; else EST="$(size_of $INCLUDE)"; fi
+log "scope: ${first} -> ${INCLUDE:-<everything>}"
+log "estimated target: ${EST}"
+
+if [ "$DRYRUN" = "1" ]; then log "dry-run: nothing pulled"; exit 0; fi
+
+# ── Ensure git-lfs ─────────────────────────────────────────────────────────
+if ! command -v git-lfs >/dev/null 2>&1; then
+  log "installing git-lfs"
+  ( apt-get install -y git-lfs >/dev/null 2>&1 || sudo apt-get install -y git-lfs >/dev/null 2>&1 ) \
+    || { log "could not install git-lfs"; exit 1; }
+fi
+git -C "$PROJECT_REPO" lfs install --skip-smudge >/dev/null 2>&1 || true
+
+# ── Pull + materialize ────────────────────────────────────────────────────
+if [ -z "$INCLUDE" ]; then
+  log "pulling ALL LFS objects (this is large)"
+  git -C "$PROJECT_REPO" lfs pull >/dev/null 2>&1 || log "lfs pull error (network policy?)"
+  git -C "$PROJECT_REPO" lfs checkout >/dev/null 2>&1 || true
+else
+  inc_args=""; for g in $INCLUDE; do inc_args="$inc_args --include=$g"; done
+  # shellcheck disable=SC2086
+  git -C "$PROJECT_REPO" lfs pull $inc_args >/dev/null 2>&1 || log "lfs pull error (network policy?); trying checkout from cache"
+  for g in $INCLUDE; do git -C "$PROJECT_REPO" lfs checkout "${g%/**}" >/dev/null 2>&1 || true; done
+fi
+
+# ── Verify by count of materialized (>1 KB) assets ────────────────────────
+real_ct=0
+if [ -z "$INCLUDE" ]; then roots="Content"; else roots=""; for g in $INCLUDE; do roots="$roots ${g%/**}"; done; fi
+for r in $roots; do
+  d="$PROJECT_REPO/$r"; [ -d "$d" ] || continue
+  n=$(find "$d" \( -name '*.uasset' -o -name '*.umap' \) -size +1k 2>/dev/null | wc -l)
+  real_ct=$((real_ct + n))
+done
+if [ "$real_ct" -gt 0 ]; then
+  log "OK — $real_ct binaries materialized for offline introspection"
+else
+  log "WARN — no binaries materialized; offline tools limited to text-derived data"
+  exit 1
+fi

--- a/.claude/scripts/uemcp-offline.mjs
+++ b/.claude/scripts/uemcp-offline.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// uemcp-offline.mjs — run any UEMCP OFFLINE tool against this project on disk,
+// with no Unreal Editor and no MCP handshake. This is the guaranteed-reliable
+// path for cloud/headless sessions.
+//
+// Usage:
+//   node .claude/scripts/uemcp-offline.mjs <tool> [jsonArgs]
+//   node .claude/scripts/uemcp-offline.mjs                 # lists offline tools
+//
+// Examples:
+//   node .claude/scripts/uemcp-offline.mjs project_info
+//   node .claude/scripts/uemcp-offline.mjs query_asset_registry '{"path_prefix":"/Game/ProjectFiles/Data/PDA/Attack","limit":200}'
+//   node .claude/scripts/uemcp-offline.mjs read_asset_properties '{"asset_path":"Content/ProjectFiles/Data/PDA/Attack/AttackConfigurations/DA_Config_Katana.uasset"}'
+//
+// Env:
+//   UEMCP_HOME            server location   (default: $HOME/uemcp)
+//   UNREAL_PROJECT_ROOT   project to read   (default: this repo's root)
+import { pathToFileURL } from 'node:url';
+import { existsSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+
+const OFFLINE_TOOLS = [
+  'project_info', 'get_asset_info', 'query_asset_registry', 'read_asset_properties',
+  'list_asset_exports', 'inspect_blueprint', 'list_level_actors', 'list_gameplay_tags',
+  'search_gameplay_tags', 'list_config_values', 'bp_list_graphs', 'bp_list_entry_points',
+  'bp_find_in_graph', 'bp_show_node', 'bp_trace_exec', 'bp_trace_data',
+  'find_blueprint_nodes', 'find_blueprint_nodes_bulk',
+];
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..'); // .claude/scripts -> repo root
+const UEMCP_HOME = process.env.UEMCP_HOME || join(os.homedir(), 'uemcp');
+const PROJECT_ROOT = process.env.UNREAL_PROJECT_ROOT || repoRoot;
+const offlineToolsPath = join(UEMCP_HOME, 'server', 'offline-tools.mjs');
+
+const [, , tool, rawArgs] = process.argv;
+
+function fail(msg, code = 1) { console.error(`[uemcp-offline] ${msg}`); process.exit(code); }
+
+if (!tool || tool === '-h' || tool === '--help') {
+  console.log('UEMCP offline tools:\n  ' + OFFLINE_TOOLS.join('\n  '));
+  console.log('\nUsage: node .claude/scripts/uemcp-offline.mjs <tool> [jsonArgs]');
+  process.exit(0);
+}
+if (!existsSync(offlineToolsPath)) {
+  fail(`UEMCP not provisioned at ${UEMCP_HOME}. Run: bash .claude/scripts/uemcp-cloud-bootstrap.sh`);
+}
+
+let args = {};
+if (rawArgs) {
+  try { args = JSON.parse(rawArgs); }
+  catch (e) { fail(`arguments must be valid JSON: ${e.message}`); }
+}
+
+const mod = await import(pathToFileURL(offlineToolsPath).href);
+const exec = mod.executeOfflineTool;
+if (typeof exec !== 'function') fail('executeOfflineTool export not found in offline-tools.mjs');
+
+try {
+  const result = await exec(tool, args, PROJECT_ROOT);
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+} catch (e) {
+  fail(`${tool} failed: ${e.message}`);
+}

--- a/.claude/scripts/uemcp-session-start.sh
+++ b/.claude/scripts/uemcp-session-start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SessionStart hook (cloud/Linux only): materialize this project's LFS binaries
+# so UEMCP offline tools parse real .uasset/.umap bytes instead of ~130 B
+# pointer stubs (which fail with "bad magic 0x73726576").
+#
+# No-op everywhere else: on Windows/local machines the working copy already has
+# real binaries, and on non-Linux uname this exits immediately.
+#
+# Scope: UEMCP_LFS_SCOPE if set (project | anims | marketplace | all), else
+# project (~2 MB). Expand mid-session with:
+#   bash .claude/scripts/uemcp-lfs-pull.sh <scope|glob> [--dry-run]
+set -u
+
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  Linux) : ;;
+  *) exit 0 ;;
+esac
+
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+# Fast exit if binaries are already materialized (hook also fires on resume).
+sample="$(find "$DIR/../../Content/ProjectFiles" -name '*.uasset' -size +1k -print 2>/dev/null | head -1)"
+[ -n "$sample" ] && exit 0
+
+bash "$DIR/uemcp-lfs-pull.sh" "${UEMCP_LFS_SCOPE:-project}" || true
+exit 0

--- a/.claude/scripts/uemcp-session-start.sh
+++ b/.claude/scripts/uemcp-session-start.sh
@@ -3,8 +3,12 @@
 # so UEMCP offline tools parse real .uasset/.umap bytes instead of ~130 B
 # pointer stubs (which fail with "bad magic 0x73726576").
 #
-# No-op everywhere else: on Windows/local machines the working copy already has
-# real binaries, and on non-Linux uname this exits immediately.
+# CLOUD-ONLY by three layered guards (any one suffices to no-op locally):
+#   1. non-Linux uname (Windows/git-bash/macOS) -> exit
+#   2. no Claude-cloud container marker in env  -> exit
+#   3. binaries already real (local clones, resumed sessions) -> exit
+# On local machines the working copy already has real binaries, so even if the
+# env markers are ever renamed upstream, guards 1/3 still keep this inert.
 #
 # Scope: UEMCP_LFS_SCOPE if set (project | anims | marketplace | all), else
 # project (~2 MB). Expand mid-session with:
@@ -15,6 +19,12 @@ case "$(uname -s 2>/dev/null || echo unknown)" in
   Linux) : ;;
   *) exit 0 ;;
 esac
+
+# Cloud/remote container markers (Claude Code on the web / mobile sessions).
+# If neither is present, this is a local Linux machine — stay out of its way.
+if [ -z "${CLAUDE_CODE_CONTAINER_ID:-}" ] && [ "${CCR_AGENT_PROXY_ENABLED:-0}" != "1" ]; then
+  exit 0
+fi
 
 DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/scripts/uemcp-session-start.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -12,6 +12,14 @@
         "UNREAL_RC_PORT": "30010",
         "UNREAL_AUTO_DETECT": "true"
       }
+    },
+    "uemcp-offline": {
+      "command": "node",
+      "args": ["${HOME}/uemcp/server/server.mjs"],
+      "env": {
+        "UNREAL_PROJECT_NAME": "KatanaCombat"
+      }
     }
-  }
+  },
+  "_uemcp_offline_note": "Cloud/Linux (Claude Code on the web) offline bridge. Provisioned by .claude/scripts/uemcp-cloud-bootstrap.sh (run it from the environment setup script). Serves ONLY the offline toolset (disk-only asset/config/blueprint reads); the live TCP/RC layers stay dormant with no editor. Auto-attaches to this project via the workspace root the harness advertises. On Windows/local, ${HOME}/uemcp does not exist so this entry is inert and the native 'uemcp' entry above is used instead. See .claude/UEMCP_CLOUD.md."
 }


### PR DESCRIPTION
## Summary

Makes UEMCP's **offline toolset** (disk-only `.uasset`/`.umap`/`.ini`/AssetRegistry introspection) work in cloud Claude Code sessions (web/mobile), where no Unreal Editor exists and the live TCP:55558 / RC:30010 layers cannot run. Cloud sessions now self-provision with zero manual steps; local Windows/Linux checkouts are never touched.

## What's included

- **`.claude/scripts/uemcp-cloud-bootstrap.sh`** — idempotent clone+install of the public `uemcp` repo into `$HOME/uemcp` (retry/backoff clone, lockfile-stamped `npm ci`, headless smoke check). Delegates binary provisioning to the LFS pull script.
- **`.claude/scripts/uemcp-lfs-pull.sh`** — single source of truth for materializing LFS binaries (cloud clones arrive as ~130 B pointer stubs, which fail binary parsing with `bad magic 0x73726576`). Scope presets: `project` (default, ~2 MB / 105 assets) | `anims` (~2.85 GB) | `marketplace` (~4.27 GB) | `all` (~4.28 GB), plus explicit globs and `--dry-run` size estimates. Runnable standalone mid-session to expand scope; cached objects are not re-downloaded.
- **`.claude/scripts/uemcp-session-start.sh`** + **`.claude/settings.json`** — SessionStart hook that auto-pulls the `project` scope in cloud sessions only, gated by three layered guards: non-Linux exit, cloud container env-marker check (`CLAUDE_CODE_CONTAINER_ID` / `CCR_AGENT_PROXY_ENABLED`), and already-materialized fast-exit (~9 ms).
- **`.claude/scripts/uemcp-offline.mjs`** — CLI wrapper driving offline tools directly via `executeOfflineTool` (no MCP handshake needed).
- **`.mcp.json`** — additive `uemcp-offline` server entry pointing at `${HOME}/uemcp/server/server.mjs`; inert on Windows/local where that path doesn't exist, so the existing `uemcp` entry is unaffected.
- **`.claude/UEMCP_CLOUD.md`** — layer table (offline vs live), scope presets, setup wiring, and known limitations.

## Verification

- Offline server boots headless and auto-attaches via harness-advertised workspace roots; native `project_info` returns correct project data.
- No-npm import path proven: `offline-tools.mjs` chain uses only `node:` builtins.
- Binary decode proven end-to-end: `read_asset_properties` resolves `DA_Configuration_Katana`'s `DefaultLightAttack`/`DefaultHeavyAttack` import references from real serialized data.
- All four SessionStart guard paths executed: cloud+materialized (9 ms no-op), local Linux with stubs (no pull), Windows uname (no-op), cloud+stubs (pulls 104 binaries).
- Shell fixes verified: `set -euf` keeps LFS include globs literal; scope-root verification counts are scope-accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ib4xFsPMZ2L8PwKChhs3r

---
_Generated by [Claude Code](https://claude.ai/code/session_017ib4xFsPMZ2L8PwKChhs3r)_