### PR TITLE
Harden enemy AI proof lifecycle

### DIFF
--- a/.agents/skills/katana-verify/scripts/summarize-automation-log.ps1
+++ b/.agents/skills/katana-verify/scripts/summarize-automation-log.ps1
@@ -10,7 +10,7 @@ if (-not (Test-Path -LiteralPath $LogPath)) {
 }
 
 $Completed = Select-String -Path $LogPath -Pattern "Test Completed.*Result=" -ErrorAction SilentlyContinue
-$Failures = Select-String -Path $LogPath -Pattern "Test Completed\. Result=\{(Fail|Failed|Error|Cancelled|Timeout)\}|LogAutomation(CommandLine|Controller|Worker).*Error:" -ErrorAction SilentlyContinue
+$Failures = Select-String -Path $LogPath -Pattern "Test Completed\. Result=\{(Fail|Failed|Error|Cancelled|Timeout)\}|LogAutomation(CommandLine|Controller|Worker): Error:" -ErrorAction SilentlyContinue
 $Warnings = Select-String -Path $LogPath -Pattern "Warning:.*Automation|Automation.*Warning" -ErrorAction SilentlyContinue
 
 $Summary = [ordered]@{

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Data-driven attack configuration via AttackData assets
 - Per-hit impact effects (hitstop, audio, VFX) with pooled FX data assets
 - Death system with directional animations and ragdoll transitions
-- Comprehensive test suite (368 tests, all passing)
+- Comprehensive automation suite with current counts reported by the standard baseline runner
 
 ## Build & Development
 
@@ -31,24 +31,16 @@ dotnet "..\..\Engine\Binaries\DotNET\UnrealBuildTool\UnrealBuildTool.dll" Katana
 2. Automation tab → Filter: "KatanaCombat"
 3. Select tests and click "Start Tests"
 
-**Run Tests** (Command Line):
+**Run Tests** (Command Line, preferred):
 ```powershell
-# Run tests in background (don't wait for completion callback - it hangs)
-"C:\Program Files\Epic Games\UE_5.6\Engine\Binaries\Win64\UnrealEditor-Cmd.exe" "D:\UnrealProjects\5.6\KatanaCombat\KatanaCombat.uproject" -ExecCmds="Automation RunTests KatanaCombat" -unattended -nopause -NullRHI -nosplash -stdout
+powershell -NoProfile -ExecutionPolicy Bypass -File "Tools\Codex\run-agent-baseline.ps1"
 ```
 
-**IMPORTANT**: The test command doesn't return a clean exit. Run it in background, wait ~5 minutes, then kill the process and check the log manually. This is the standard workflow.
+The baseline builds `KatanaCombatEditor`, runs `Automation RunTests KatanaCombat` with `;Quit`, writes timestamped evidence under `Saved/Logs/`, and exits nonzero on detected build or test failure. Direct `UnrealEditor-Cmd.exe` runs may still fail to exit cleanly; inspect the log rather than treating a lingering process as proof of failure.
 
 **Test Results**: Check the log file at `D:\UnrealProjects\5.6\KatanaCombat\Saved\Logs\KatanaCombat.log`
 ```powershell
-# View test results summary (pass/fail counts)
-grep -E "Test Completed.*Result=" D:/UnrealProjects/5.6/KatanaCombat/Saved/Logs/KatanaCombat.log | sed 's/.*Result={\([^}]*\)}.*/\1/' | sort | uniq -c
-
-# View failing tests with error messages
-grep -E "Error:" D:/UnrealProjects/5.6/KatanaCombat/Saved/Logs/KatanaCombat.log | grep -i "automation\|test" | head -20
-
-# View specific test failures
-grep -E "Test Completed.*Fail" D:/UnrealProjects/5.6/KatanaCombat/Saved/Logs/KatanaCombat.log
+powershell -NoProfile -ExecutionPolicy Bypass -File ".agents\skills\katana-verify\scripts\summarize-automation-log.ps1"
 ```
 
 **Debug Visualization** (CVar-controlled, use console commands):
@@ -502,7 +494,7 @@ Track ongoing work across sessions. This section provides detailed status of all
 |-----------|----------|---------|
 | Counter Animations | P1 | Parry, counter attack, chain finisher montages needed |
 | SpecificCounterData Wiring | P1 | In scope for Chain branch: selected `AttackData::CounterData` first; `SpecificCounterData` is an explicit fallback only. |
-| AI Attack Token System | P2 | Phase 5b-5 - `UCombatTokenSubsystem` |
+| Production Enemy AI | P2 | Minimal StateTree + `UCombatTokenSubsystem` combat proof is wired; perception, patrol, tactics, and production tuning remain future work. |
 
 #### Editor/Runtime Unification Gap (Needs Further Inquiry)
 
@@ -575,7 +567,7 @@ Player Input → CombatComponent::ExecuteAction()
 
 ## Test Suite
 
-**Coverage**: 368 tests (all passing)
+**Coverage**: Run the standard baseline for the current completed-result and failure counts. The dated baseline in `Source/KatanaCombatTest/README.md` is historical evidence, not a live total.
 
 **Run Tests**:
 - Editor: `Window → Developer Tools → Session Frontend → Automation tab → Filter: "KatanaCombat"`

--- a/Source/KatanaCombat/Private/AI/EnemyCombatAIComponent.cpp
+++ b/Source/KatanaCombat/Private/AI/EnemyCombatAIComponent.cpp
@@ -123,6 +123,21 @@ bool UEnemyCombatAIComponent::TryInitiateAttack()
 	}
 }
 
+void UEnemyCombatAIComponent::CancelQueuedAttackRequest()
+{
+	bWaitingForTokenGrant = false;
+
+	if (TokenSubsystem && TokenSubsystem->IsInTokenQueue(GetOwner()))
+	{
+		TokenSubsystem->RemoveFromQueue(GetOwner());
+	}
+
+	if (!HasAttackToken())
+	{
+		SelectedAttack = nullptr;
+	}
+}
+
 bool UEnemyCombatAIComponent::ExecuteAttack()
 {
 	if (CurrentState != EEnemyAIState::Approaching)

--- a/Source/KatanaCombat/Private/AI/EnemyCombatStateTreeTasks.cpp
+++ b/Source/KatanaCombat/Private/AI/EnemyCombatStateTreeTasks.cpp
@@ -142,9 +142,22 @@ EStateTreeRunStatus FStateTreeRequestEnemyAttackTokenTask::Tick(FStateTreeExecut
 		return EStateTreeRunStatus::Failed;
 	}
 
-	return InstanceData.ElapsedTime >= InstanceData.MaxQueueWaitTime
-		? EStateTreeRunStatus::Failed
-		: EStateTreeRunStatus::Running;
+	if (InstanceData.ElapsedTime >= InstanceData.MaxQueueWaitTime)
+	{
+		CombatAI->CancelQueuedAttackRequest();
+		return EStateTreeRunStatus::Failed;
+	}
+
+	return EStateTreeRunStatus::Running;
+}
+
+void FStateTreeRequestEnemyAttackTokenTask::ExitState(FStateTreeExecutionContext& Context, const FStateTreeTransitionResult& Transition) const
+{
+	const FInstanceDataType& InstanceData = Context.GetInstanceData(*this);
+	if (UEnemyCombatAIComponent* CombatAI = FindEnemyCombatAI(InstanceData.EnemyActor))
+	{
+		CombatAI->CancelQueuedAttackRequest();
+	}
 }
 
 EStateTreeRunStatus FStateTreeCircleEnemyCombatTargetTask::EnterState(FStateTreeExecutionContext& Context, const FStateTreeTransitionResult& Transition) const

--- a/Source/KatanaCombat/Public/AI/EnemyCombatAIComponent.h
+++ b/Source/KatanaCombat/Public/AI/EnemyCombatAIComponent.h
@@ -98,6 +98,13 @@ public:
 	bool TryInitiateAttack();
 
 	/**
+	 * Cancel a pending queued attack request without releasing an active token.
+	 * Used when a StateTree request task times out or exits before a grant.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AI|Combat")
+	void CancelQueuedAttackRequest();
+
+	/**
 	 * Execute the selected attack (called when in range)
 	 * Plays attack montage with CounterWindow notify
 	 * @return True if attack execution started

--- a/Source/KatanaCombat/Public/AI/EnemyCombatStateTreeTasks.h
+++ b/Source/KatanaCombat/Public/AI/EnemyCombatStateTreeTasks.h
@@ -67,6 +67,7 @@ struct KATANACOMBAT_API FStateTreeRequestEnemyAttackTokenTask : public FStateTre
 	virtual const UStruct* GetInstanceDataType() const override { return FInstanceDataType::StaticStruct(); }
 	virtual EStateTreeRunStatus EnterState(FStateTreeExecutionContext& Context, const FStateTreeTransitionResult& Transition) const override;
 	virtual EStateTreeRunStatus Tick(FStateTreeExecutionContext& Context, const float DeltaTime) const override;
+	virtual void ExitState(FStateTreeExecutionContext& Context, const FStateTreeTransitionResult& Transition) const override;
 
 #if WITH_EDITOR
 	virtual FText GetDescription(const FGuid& ID, FStateTreeDataView InstanceDataView, const IStateTreeBindingLookup& BindingLookup, EStateTreeNodeFormatting Formatting = EStateTreeNodeFormatting::Text) const override;

--- a/Source/KatanaCombatTest/Private/EnemyCombatAITests.cpp
+++ b/Source/KatanaCombatTest/Private/EnemyCombatAITests.cpp
@@ -14,6 +14,7 @@
 #include "Engine/GameInstance.h"
 #include "EngineUtils.h"
 #include "FileHelpers.h"
+#include "GameFramework/PlayerController.h"
 #include "InputAction.h"
 #include "InputCoreTypes.h"
 #include "InputMappingContext.h"
@@ -329,6 +330,131 @@ bool FEnemyCombatAI_QueuedTargetClearReleasesQueue::RunTest(const FString& Param
 
 	TestFalse(TEXT("Cleared queued enemy should not receive the next token"), SecondAI->HasAttackToken());
 
+	FCombatTestHelpers::DestroyTestWorld(World);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FEnemyCombatAI_QueuedTokenTimeoutRemovesRequest,
+	"KatanaCombat.EnemyAI.QueuedTokenTimeoutRemovesRequest",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FEnemyCombatAI_QueuedTokenTimeoutRemovesRequest::RunTest(const FString& Parameters)
+{
+	const FString StateTreePath = TEXT("/Game/ProjectFiles/AI/ST_EnemyCombatProof.ST_EnemyCombatProof");
+
+	UWorld* World = FCombatTestHelpers::CreateTestWorld();
+	APlayerCharacter* Player = FCombatTestHelpers::CreateTestPlayerCharacter(World);
+	APlayerController* PlayerController = World ? World->SpawnActor<APlayerController>() : nullptr;
+	AEnemyCharacter* TokenHolder = FCombatTestHelpers::CreateTestEnemyCharacter(World, FVector(100.0f, 0.0f, 0.0f));
+	AEnemyCharacter* QueuedEnemy = FCombatTestHelpers::CreateTestEnemyCharacter(World, FVector(150.0f, 0.0f, 0.0f));
+	UEnemyCombatAIComponent* HolderAI = TokenHolder ? TokenHolder->CombatAIComponent.Get() : nullptr;
+	UEnemyCombatAIComponent* QueuedAI = QueuedEnemy ? QueuedEnemy->CombatAIComponent.Get() : nullptr;
+	AEnemyCombatAIController* QueuedController = QueuedEnemy
+		? Cast<AEnemyCombatAIController>(QueuedEnemy->GetController())
+		: nullptr;
+	UEnemyStateTreeAIComponent* StateTreeComponent = QueuedController
+		? Cast<UEnemyStateTreeAIComponent>(QueuedController->GetStateTreeAIComponent())
+		: nullptr;
+	UStateTree* StateTree = Cast<UStateTree>(StaticLoadObject(UStateTree::StaticClass(), nullptr, *StateTreePath));
+	UCombatTokenSubsystem* TokenSubsystem = CreateTestTokenSubsystem();
+	UAttackData* AttackData = FCombatTestHelpers::CreateTestAttack(EAttackType::Light);
+
+	if (!Player || !PlayerController || !HolderAI || !QueuedAI || !QueuedController || !StateTreeComponent || !StateTree || !TokenSubsystem || !AttackData)
+	{
+		AddError(TEXT("Failed to create Enemy AI queued token timeout fixture"));
+		FCombatTestHelpers::DestroyTestWorld(World);
+		return false;
+	}
+
+	PlayerController->Possess(Player);
+	StateTreeComponent->StopLogic(TEXT("Configure queued token timeout test"));
+	StateTreeComponent->SetStateTree(StateTree);
+
+	HolderAI->SetTokenSubsystemForTesting(TokenSubsystem);
+	QueuedAI->SetTokenSubsystemForTesting(TokenSubsystem);
+	HolderAI->SetCombatTarget(Player);
+	QueuedAI->SetCombatTarget(Player);
+	ConfigureSingleAttack(HolderAI, AttackData);
+	ConfigureSingleAttack(QueuedAI, AttackData);
+
+	TestTrue(TEXT("First enemy should occupy the only attack token"), HolderAI->TryInitiateAttack());
+	StateTreeComponent->StartLogic();
+	StateTreeComponent->TickComponent(0.01f, ELevelTick::LEVELTICK_All, nullptr);
+
+	TestTrue(TEXT("Proof StateTree should be running while the second enemy waits"), StateTreeComponent->IsRunning());
+	TestTrue(TEXT("Second enemy should enter the token queue through the proof StateTree"), QueuedAI->IsWaitingForToken());
+
+	StateTreeComponent->TickComponent(3.1f, ELevelTick::LEVELTICK_All, nullptr);
+
+	TestFalse(TEXT("StateTree timeout should remove the pending enemy from the token queue"), QueuedAI->IsWaitingForToken());
+	TestNull(TEXT("StateTree timeout should clear the queued attack selection"), QueuedAI->SelectedAttack.Get());
+	TestEqual(TEXT("StateTree timeout should preserve the combat target"), QueuedAI->CombatTarget.Get(), static_cast<AActor*>(Player));
+	TestTrue(TEXT("Cancelling the queued request should not release another enemy's active token"), HolderAI->HasAttackToken());
+
+	StateTreeComponent->StopLogic(TEXT("Queued token timeout test cleanup"));
+	TokenSubsystem->ResetAllTokens();
+	FCombatTestHelpers::DestroyTestWorld(World);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FEnemyCombatAI_QueuedTokenStateTreeStopRemovesRequest,
+	"KatanaCombat.EnemyAI.QueuedTokenStateTreeStopRemovesRequest",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FEnemyCombatAI_QueuedTokenStateTreeStopRemovesRequest::RunTest(const FString& Parameters)
+{
+	const FString StateTreePath = TEXT("/Game/ProjectFiles/AI/ST_EnemyCombatProof.ST_EnemyCombatProof");
+
+	UWorld* World = FCombatTestHelpers::CreateTestWorld();
+	APlayerCharacter* Player = FCombatTestHelpers::CreateTestPlayerCharacter(World);
+	APlayerController* PlayerController = World ? World->SpawnActor<APlayerController>() : nullptr;
+	AEnemyCharacter* TokenHolder = FCombatTestHelpers::CreateTestEnemyCharacter(World, FVector(100.0f, 0.0f, 0.0f));
+	AEnemyCharacter* QueuedEnemy = FCombatTestHelpers::CreateTestEnemyCharacter(World, FVector(150.0f, 0.0f, 0.0f));
+	UEnemyCombatAIComponent* HolderAI = TokenHolder ? TokenHolder->CombatAIComponent.Get() : nullptr;
+	UEnemyCombatAIComponent* QueuedAI = QueuedEnemy ? QueuedEnemy->CombatAIComponent.Get() : nullptr;
+	AEnemyCombatAIController* QueuedController = QueuedEnemy
+		? Cast<AEnemyCombatAIController>(QueuedEnemy->GetController())
+		: nullptr;
+	UEnemyStateTreeAIComponent* StateTreeComponent = QueuedController
+		? Cast<UEnemyStateTreeAIComponent>(QueuedController->GetStateTreeAIComponent())
+		: nullptr;
+	UStateTree* StateTree = Cast<UStateTree>(StaticLoadObject(UStateTree::StaticClass(), nullptr, *StateTreePath));
+	UCombatTokenSubsystem* TokenSubsystem = CreateTestTokenSubsystem();
+	UAttackData* AttackData = FCombatTestHelpers::CreateTestAttack(EAttackType::Light);
+
+	if (!Player || !PlayerController || !HolderAI || !QueuedAI || !QueuedController || !StateTreeComponent || !StateTree || !TokenSubsystem || !AttackData)
+	{
+		AddError(TEXT("Failed to create Enemy AI queued StateTree stop fixture"));
+		FCombatTestHelpers::DestroyTestWorld(World);
+		return false;
+	}
+
+	PlayerController->Possess(Player);
+	StateTreeComponent->StopLogic(TEXT("Configure queued StateTree stop test"));
+	StateTreeComponent->SetStateTree(StateTree);
+
+	HolderAI->SetTokenSubsystemForTesting(TokenSubsystem);
+	QueuedAI->SetTokenSubsystemForTesting(TokenSubsystem);
+	HolderAI->SetCombatTarget(Player);
+	QueuedAI->SetCombatTarget(Player);
+	ConfigureSingleAttack(HolderAI, AttackData);
+	ConfigureSingleAttack(QueuedAI, AttackData);
+
+	TestTrue(TEXT("First enemy should occupy the only attack token"), HolderAI->TryInitiateAttack());
+	StateTreeComponent->StartLogic();
+	StateTreeComponent->TickComponent(0.01f, ELevelTick::LEVELTICK_All, nullptr);
+
+	TestTrue(TEXT("Second enemy should enter the token queue before StateTree stop"), QueuedAI->IsWaitingForToken());
+	TestNotNull(TEXT("Queued request should retain its selected attack while waiting"), QueuedAI->SelectedAttack.Get());
+
+	StateTreeComponent->StopLogic(TEXT("Cancel queued token request"));
+
+	TestFalse(TEXT("Stopping the StateTree should remove the pending enemy from the token queue"), QueuedAI->IsWaitingForToken());
+	TestNull(TEXT("Stopping the StateTree should clear the queued attack selection"), QueuedAI->SelectedAttack.Get());
+	TestEqual(TEXT("Stopping the StateTree should preserve the combat target"), QueuedAI->CombatTarget.Get(), static_cast<AActor*>(Player));
+	TestTrue(TEXT("Stopping a queued request should not release another enemy's active token"), HolderAI->HasAttackToken());
+
+	TokenSubsystem->ResetAllTokens();
 	FCombatTestHelpers::DestroyTestWorld(World);
 	return true;
 }

--- a/docs/architecture/ARCHITECTURE_QUICK.md
+++ b/docs/architecture/ARCHITECTURE_QUICK.md
@@ -384,7 +384,9 @@ bool IsVulnerableToFinisher() const;
 
 KatanaCombat includes a comprehensive **C++ unit test suite** (`KatanaCombatTest` module):
 
-### Test Coverage (19 Test Suites, 368 Tests)
+### Test Coverage
+
+The suite changes with active combat work. Use the standard baseline and `Source/KatanaCombatTest/README.md` for current result counts instead of treating this architecture reference as a live total.
 
 **Core Combat**:
 1. **StateTransitionTests** - State machine validation

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -439,7 +439,8 @@ IA_HeavyAttack:
 - Right Mouse Button
 
 IA_Block:
-- Middle Mouse Button
+- Thumb Mouse Button
+- Gamepad Left Shoulder
 
 IA_Evade:
 - Spacebar

--- a/docs/guides/HEADLESS_ASSET_MIGRATIONS.md
+++ b/docs/guides/HEADLESS_ASSET_MIGRATIONS.md
@@ -94,7 +94,7 @@ Readiness rows report `CounterData`, `FinisherData`, parry/counter window presen
 
 ## Enemy AI Proof Assets
 
-Use `EnemyAIProofAssets` to create or refresh the minimal playable enemy AI proof slice. This operation does not use a target file. It creates or updates `/Game/ProjectFiles/AI/ST_EnemyCombatProof`, creates or updates `/Game/ProjectFiles/AI/BP_EnemyCombatAIController`, assigns that controller and a fallback attack on `/Game/ProjectFiles/Core/Actors/Character/BP_EnemyCharacter`, then loads `/Game/ProjectFiles/Levels/Lvl_ThirdPerson1` to validate placed enemies.
+Use `EnemyAIProofAssets` to create or refresh the minimal playable enemy AI proof slice. This operation does not use a target file. It creates or updates `/Game/ProjectFiles/AI/ST_EnemyCombatProof` and `/Game/ProjectFiles/AI/BP_EnemyCombatAIController`, assigns that controller and a fallback attack on `/Game/ProjectFiles/Core/Actors/Character/BP_EnemyCharacter`, and loads `/Game/ProjectFiles/Levels/Lvl_ThirdPerson1` to validate placed enemies. It also creates or repairs Boolean `/Game/ProjectFiles/Input/Actions/IA_Block`, assigns it and the combat mapping context on `/Game/ProjectFiles/Core/Actors/Character/BP_Player`, maps block to Thumb Mouse Button and Gamepad Left Shoulder in `/Game/ProjectFiles/Input/IMC_Combat`, and removes the deprecated Right Mouse Button block mapping so that binding remains available for heavy attack.
 
 Plan the proof asset update:
 
@@ -108,4 +108,4 @@ Apply and save only after reviewing the planned package list:
 &"C:\Program Files\Epic Games\UE_5.6\Engine\Binaries\Win64\UnrealEditor-Cmd.exe" "D:\UnrealProjects\5.6\KatanaCombat\KatanaCombat.uproject" -run=KatanaAssetMigration -Operation=EnemyAIProofAssets -Mode=ApplyAndSave -AllowPackageSave -ReportPath="Saved/Logs/Commandlets/KatanaAssetMigration/enemy-ai-proof-assets-save.json" -unattended -nopause -NullRHI -nosplash -stdout
 ```
 
-Re-run `Plan` after saving. Expected post-save result is `Unchanged`, with a warning that records how many `AEnemyCharacter` actors loaded from `Lvl_ThirdPerson1` and how many already had usable attacks. The operation only saves changed AI, controller, and enemy Blueprint packages; it should not resave the level or external actor packages unless a placed enemy is missing required defaults.
+Re-run `Plan` after saving. Expected post-save result is `Unchanged`, with a warning that records how many `AEnemyCharacter` actors loaded from `Lvl_ThirdPerson1` and how many already had usable attacks. Review the report for every package before allowing saves: depending on detected drift, the operation may save the StateTree, controller Blueprint, enemy Blueprint, player Blueprint, `IA_Block`, and `IMC_Combat`. It should not resave the level or external actor packages unless a placed enemy is missing required defaults.

--- a/docs/plans/basic-combat-proof-enemy.md
+++ b/docs/plans/basic-combat-proof-enemy.md
@@ -21,6 +21,7 @@ KatanaCombat already has `UEnemyCombatAIComponent` and `UCombatTokenSubsystem`, 
 - Automation can inject a deterministic `UCombatTokenSubsystem` when synthetic worlds do not own a normal `GameInstance`.
 - Attack execution failure releases tokens and returns to `Circling` or `Idle` instead of leaving enemies stuck in `Approaching`.
 - Queued enemies leave the token queue if their combat target is cleared before a token is granted.
+- A StateTree token wait that times out or exits while still queued cancels its pending request without releasing an active token.
 
 ## Canonical AI Model
 
@@ -40,6 +41,7 @@ KatanaCombat already has `UEnemyCombatAIComponent` and `UCombatTokenSubsystem`, 
 - A configured enemy can request a token, select an attack, and enter `Approaching`.
 - A queued enemy receives the token when the current token holder is parried/interrupted.
 - A queued enemy that loses its target does not receive the next released token.
+- A queued enemy whose StateTree token wait expires is removed from the queue and can retry through the normal recovery loop.
 - Failed attack execution cleans up token and selected attack state.
 - Active source no longer contains project enemy Behavior Tree task/decorator implementations.
 


### PR DESCRIPTION
## Summary

- Cancel queued enemy attack-token requests when the StateTree request task times out or exits, without releasing an active token or clearing a granted attack.
- Add integration regressions for timeout and explicit StateTree stop cleanup.
- Reconcile enemy proof, block-input, commandlet, architecture, and live test-count documentation.
- Tighten the automation log summarizer so warning payloads containing `error:` do not become false test failures.

## Why

A timed-out StateTree request returned failure while leaving the enemy in the combat-token queue with its selected attack retained. That stale request could later receive a token after the task had moved on. The verification parser also treated forwarded EOS connectivity warnings such as `libcurl error` as automation failures despite every test succeeding.

## Impact

Queued enemies now cleanly withdraw when their request lifecycle ends, while successful token grants retain their active-token state. Agentic verification produces accurate pass/fail results, and the contributor documentation reflects the current playable enemy proof slice and block mappings.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File "Tools\Codex\run-agent-baseline.ps1"`
  - `KatanaCombatEditor Win64 Development`: passed
  - Automation: 439 completed, 0 failures/errors
  - Result: `BASELINE GREEN`
- Focused regressions:
  - `KatanaCombat.EnemyAI.QueuedTokenTimeoutRemovesRequest`
  - `KatanaCombat.EnemyAI.QueuedTokenStateTreeStopRemovesRequest`
- `EnemyAIProofAssets -Mode=Plan`: `Unchanged`, `would_change: 0`; four placed enemies had usable attacks.
- Summarizer verification: real warning-bearing log exits 0; synthetic failed-test and true automation-error logs exit 2.
- `git diff --check`: passed.